### PR TITLE
improved headwords display

### DIFF
--- a/src/dictionaryUtils.ts
+++ b/src/dictionaryUtils.ts
@@ -151,15 +151,13 @@ async function addTermEntry({
   ] as StructuredContentNode[];
   if (simplified !== traditional)
     terms.unshift(
-      ...([
-        {
-          tag: 'span',
-          content: traditional,
-          lang: 'zh-Hant',
-          data: { cccedict: 'headword-trad' },
-        },
-        '・',
-      ] as StructuredContentNode[])
+      {
+        tag: 'span',
+        content: traditional,
+        lang: 'zh-Hant',
+        data: { cccedict: 'headword-trad' },
+      },
+      '・'
     );
   // Build definition
   termEntry.addDetailedDefinition({


### PR DESCRIPTION
Added the `lang` attribute to traditional and simplified headwords, such so the browser displays them in the appropriate font.
Compare before (both versions use the Simplified Chinese font by the browser): \
<img width="664" height="139" alt="image" src="https://github.com/user-attachments/assets/4e6df080-8e5c-4ae0-81dc-a821b10a3e22" />
And after (traditional use Traditional Chinese font, Simplified uses Simplified): \
<img width="674" height="137" alt="image" src="https://github.com/user-attachments/assets/6f9af03e-0144-41e6-9154-72a47150e17c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Headword rendering now uses structured content nodes so simplified and traditional forms display with proper language tags and a visible separator, improving clarity and multi-script support in dictionary entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->